### PR TITLE
Fixed HPF Non-preemptive job completion return

### DIFF
--- a/hw2/main.cpp
+++ b/hw2/main.cpp
@@ -462,7 +462,12 @@ AlgoRet hpf_non_preemptive(const Job *job, int njobs, PerJobStats *stats, char *
         } 
       }
       ptop = pque.ptr_top(); 
+    } // end of while()
+   
+    // return jobs completed, elapsed quanta
+    if (pque.size() == 0) {
+      return {j, q};
+    } else {
+      return {j-int(pque.size()), q};
     }
-    
-    return {j-int(pque.size())-1, q}; //jobs completed, elapsed quanta
 }


### PR DESCRIPTION
* HPF non-preemptive return statement (# of jobs completed) was incorrect
* if there is nothing in the queue, then all 12 jobs completed otherwise it is
* total jobs minus whatever is left in the queue